### PR TITLE
Set cwd as default module if no module is set

### DIFF
--- a/git-reqs
+++ b/git-reqs
@@ -34,7 +34,7 @@ def import_reqs(args):
     elif args.format == 'md':
         importtools.import_from_markdown(req_module, args.file)
     else:
-        assert False
+        assert False, "Invalid format. See available formats with git-reqs import --help"
 
     req_module.write_reqs()
 
@@ -49,6 +49,8 @@ def export_reqs(args):
         exporttools.convert_to_xls(req_module, os.path.abspath(args.project_root), args.module, os.path.abspath(__file__))
     elif args.format == 'md':
         exporttools.convert_to_markdown(req_module)
+    else:
+        assert False, "Invalid format. See available formats with git-reqs export --help"
 
 
 def create_report(args):
@@ -56,6 +58,7 @@ def create_report(args):
 
     if args.type == 'relations':
         exporttools.create_report(project, args.module)
+
 
 
 if __name__ == "__main__":

--- a/git-reqs
+++ b/git-reqs
@@ -18,9 +18,14 @@ def init(args):
 
 
 def import_reqs(args):
-    module_path = args.project_root + '/' + args.module
     project = requirement_module(args.project_root)
-    req_module = project.modules[args.module]
+    if args.module:
+        req_module = project.modules[args.module]
+        module_path = args.project_root + '/' + args.module
+    else:
+        req_module = project
+        module_path = args.project_root
+
     if args.format == 'junit':
         importtools.add_test_results(module_path, args.file)
         project = requirement_module(args.project_root)
@@ -36,9 +41,12 @@ def import_reqs(args):
 
 def export_reqs(args):
     project = requirement_module(args.project_root)
-    req_module = project.modules[args.module]
+    if args.module:
+        req_module = project.modules[args.module]
+    else:
+        req_module = project
     if args.format == 'xls':
-        exporttools.convert_to_xls(req_module)
+        exporttools.convert_to_xls(req_module, os.path.abspath(args.project_root), args.module, os.path.abspath(__file__))
     elif args.format == 'md':
         exporttools.convert_to_markdown(req_module)
 

--- a/git_reqs/exporttools.py
+++ b/git_reqs/exporttools.py
@@ -15,11 +15,11 @@ def convert_to_xls(reqmodule):
                 sheet.write(k+1, i, reqmodule.reqs.nodes[req][field])
 
         sheet.write(0, i, field)
-    workbook.save(reqmodule.module_path + "/test.xls")
+    workbook.save(reqmodule.module_path + "/" + reqmodule.module_prefix + ".xls")
 
 
 def convert_to_markdown(reqmodule, hugo=False):
-    md_file = open(reqmodule.module_path + "/reqs.md", 'w')
+    md_file = open(reqmodule.module_path + "/" + reqmodule.module_prefix + ".md", 'w')
     if hugo:
         md_file.write('---\n'
                       'title: ' + os.path.basename(reqmodule.module_path) + '\n' 
@@ -83,7 +83,7 @@ def convert_to_markdown(reqmodule, hugo=False):
 
 
 def create_report(project, reqmodule):
-    md_file = open(project.modules[reqmodule].module_path + "/report.md", 'w')
+    md_file = open(reqmodule.module_path + "/" + reqmodule.module_prefix + "_report.md", 'w')
 
     for req in project.modules[reqmodule].ordered_req_names:
 


### PR DESCRIPTION
When calling import or export, if no module is given, assume the project root being the wanted module (i.e the current working directory if no project root also is not given) 